### PR TITLE
chore: update mcp-auto-install package

### DIFF
--- a/.changeset/smart-doors-report.md
+++ b/.changeset/smart-doors-report.md
@@ -1,0 +1,5 @@
+---
+'@mcpmarket/mcp-auto-install': patch
+---
+
+update @mcpmarket/mcp-auto-install

--- a/packages/mcp-auto-install/LICENSE
+++ b/packages/mcp-auto-install/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 whatprototype
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-auto-install/README.md
+++ b/packages/mcp-auto-install/README.md
@@ -2,6 +2,107 @@
 
 A powerful MCP server with CLI that integrates into your client's MCP ecosystem. It enables you to install and manage other MCP servers through natural language conversations with LLMs. By default, it discovers MCP servers from the `@modelcontextprotocol` scope, but you can customize the sources using the `add-source` command.
 
+## ✨ Features
+
+- **Natural Language Interaction**: Install and manage MCP servers through natural language conversations with LLMs
+- **Automatic Server Discovery**: Automatically discovers MCP servers from the `@modelcontextprotocol` scope
+- **Custom Source Management**: Add and manage custom MCP server sources
+- **Command Configuration**: Save and manage server commands with environment variables
+- **Server Documentation**: Access server READMEs directly through the CLI
+- **Direct MCP Connection**: Quick connection to MCP services using npx
+
+## 📦 Installation
+
+You can install this package in two ways:
+
+1. **Global Installation**:
+
+   ```bash
+   pnpm add -g @mcpmarket/mcp-auto-install
+   ```
+
+2. **Direct Execution with npx**:
+
+   ```bash
+   # Connect to MCP service
+   npx -y @mcpmarket/mcp-auto-install connect
+
+   # Use CLI commands
+   npx @mcpmarket/mcp-auto-install [command] [options]
+   ```
+
+## 🚀 Usage
+
+### Connecting to MCP Service
+
+```bash
+# Quick connection using npx
+npx -y @mcpmarket/mcp-auto-install connect
+```
+
+### Managing Server Sources
+
+```bash
+# Add a new server source
+mcp-auto-install add-source my-server -r https://github.com/username/repo -c "npx @modelcontextprotocol/server-name" -d "My MCP Server"
+
+# List registered servers
+mcp-auto-install list
+
+# Remove a server
+mcp-auto-install remove my-server
+```
+
+### Installing Servers
+
+```bash
+# Install a server
+mcp-auto-install install my-server
+```
+
+### Managing Commands
+
+```bash
+# Save a command for a server
+mcp-auto-install save-command my-server npx @modelcontextprotocol/server-name --port 3000 --env NODE_ENV=production
+```
+
+### Viewing Documentation
+
+```bash
+# Get server README
+mcp-auto-install readme my-server
+```
+
+## 🔧 Configuration
+
+The tool uses two configuration files:
+
+1. **MCP Registry** (`mcp-registry.json`): Stores information about registered MCP server sources
+
+   - Windows: `%APPDATA%\mcp\mcp-registry.json`
+   - macOS/Linux: `~/.mcp/mcp-registry.json`
+
+2. **External Configuration**: Specified by the `MCP_SETTINGS_PATH` environment variable, used for storing server command configurations
+
+### Environment Variables
+
+- `MCP_SETTINGS_PATH`: Path to the LLM (e.g., Claude) MCP service configuration file
+  ```bash
+  export MCP_SETTINGS_PATH="/Users/username/Library/Application Support/Claude/claude_desktop_config.json"
+  ```
+
+## 📝 Version History
+
+- v0.0.4: Added direct MCP connection support with npx
+- v0.0.3: Added support for npx execution and improved command management
+- v0.0.2: Added server source management and command configuration
+- v0.0.1: Initial release with basic MCP server installation functionality
+
+## 📜 License
+
+[MIT](./LICENSE)
+
 ## 🎮 Features
 
 - 🤖 Natural language interaction with LLMs for server installation
@@ -10,123 +111,13 @@ A powerful MCP server with CLI that integrates into your client's MCP ecosystem.
 - 📚 Server documentation and README viewing
 - ⚙️ Flexible command and environment configuration
 - 🔄 Seamless integration with your MCP ecosystem
+- 🔌 Quick connection to MCP services with npx
 
 ## 📋 Prerequisites
 
 - Node.js >= 18.0.0
 - npm or pnpm package manager
 - An MCP-compatible client (e.g., Claude)
-
-## 🚀 Installation
-
-```bash
-# Using pnpm (recommended)
-pnpm add @mcpmarket/auto-install
-
-# Using npm
-npm install @mcpmarket/auto-install
-```
-
-## 💡 Usage
-
-### Basic Commands
-
-```bash
-# Start the MCP Auto Install server
-mcp-auto-install start
-
-# List all registered MCP server sources
-mcp-auto-install list
-
-# Add or update a server source in the registry
-mcp-auto-install add-source <name> -r <github-url> -c <command> -d <description> [-k <keywords>] [-i <install-commands>]
-
-# Install a server from GitHub
-mcp-auto-install install <name>
-
-# Get server README
-mcp-auto-install readme <name>
-
-# Remove a server from registry
-mcp-auto-install remove <name>
-
-# Save server command configuration
-mcp-auto-install save-command <server-name> <command> [args...] [--env KEY=VALUE]
-```
-
-### ⚙️ Configuration
-
-MCP Auto Install uses two configuration files:
-
-1. `mcp_settings.json`: Internal configuration file for storing server source information
-2. External configuration file: Specified by the `MCP_SETTINGS_PATH` environment variable, used for storing server command configurations
-
-### 🔧 Environment Variables
-
-- `MCP_SETTINGS_PATH`: Path to the external configuration file (e.g., Claude's config file)
-
-Example:
-
-```bash
-export MCP_SETTINGS_PATH="/Users/username/Library/Application Support/Claude/claude_desktop_config.json"
-```
-
-### 📝 Command Configuration Format
-
-When saving command configurations, you can specify:
-
-- Command name (e.g., 'npx', 'node', 'npm', 'yarn', 'pnpm', 'cmd', 'powershell', 'bash', 'sh', 'zsh', 'fish', 'tcsh', 'csh')
-- Command arguments (e.g., '@modelcontextprotocol/server-name', '--port', '3000', '--config', 'config.json')
-- Environment variables (e.g., --env NODE_ENV=production --env DEBUG=true)
-
-Example:
-
-```bash
-# Command: npx
-# Arguments: @modelcontextprotocol/server-name --port 3000
-# Environment: NODE_ENV=production
-mcp-auto-install save-command my-server npx @modelcontextprotocol/server-name --port 3000 --env NODE_ENV=production
-```
-
-### 🔄 JSON Configuration
-
-You can also provide server configurations in JSON format:
-
-```json
-{
-  "mcpServers": {
-    "server-name": {
-      "command": "npx",
-      "args": ["@modelcontextprotocol/server-name", "--port", "3000", "--config", "config.json"],
-      "env": {
-        "NODE_ENV": "production",
-        "DEBUG": "true"
-      }
-    }
-  }
-}
-```
-
-### 📦 Server Source Registration
-
-Each server source registration includes:
-
-- Server name and description
-- GitHub repository URL
-- Command to run the server
-- Optional keywords for server type identification
-- Optional custom installation commands
-
-## 📝 Version History
-
-- v0.0.3: Current Version
-  - Automatic server discovery
-  - Server source management
-  - GitHub-based installation
-  - README content viewing
-  - Command configuration system
-  - CLI interface
-  - External config integration
 
 ## 🤝 Contributing
 
@@ -136,10 +127,6 @@ Please see our [Contributing Guide](../../CONTRIBUTING.md) for details about:
 - Creating new packages
 - Publishing packages
 - Pull request process
-
-## 📜 License
-
-ISC
 
 ## Support
 

--- a/packages/mcp-auto-install/package.json
+++ b/packages/mcp-auto-install/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@mcpmarket/mcp-auto-install",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "MCP server that helps install other MCP servers automatically",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "mcp-auto-install": "dist/index.js"
+    "mcp-auto-install": "./dist/index.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mcp-auto-install/src/cli.ts
+++ b/packages/mcp-auto-install/src/cli.ts
@@ -11,7 +11,7 @@ import {
   handleGetServerReadme,
   saveCommandToExternalConfig,
 } from './server.js';
-
+import { checkMCPSettings } from './utils.js';
 /**
  * Command line interface for controlling MCP automatic installation servers
  */
@@ -143,35 +143,8 @@ export class MCPCliApp {
     // this.program
     //   .command("auto <request>")
     //   .description("Automatically detect and install needed MCP servers based on user request")
-    //   .option("-s, --settings <path>", "Custom path to mcp_settings.json file")
+    //   .option("-s, --settings <path>", "Custom path to mcp-registry.json file")
     //   .action(async (request: string, options) => {
-    //     try {
-    //       console.log("Analyzing request to detect needed MCP servers...");
-    //       const result = await handleAutoDetect({
-    //         userRequest: request,
-    //         settingsPath: options.settings
-    //       });
-
-    //       if (result.success) {
-    //         console.log(`✅ ${result.message}`);
-    //         if (result.serverName && result.readme) {
-    //           console.log(`\nServer: ${result.serverName}`);
-    //           console.log("\n=== README ===");
-    //           console.log(typeof result.readme === 'string'
-    //             ? `${result.readme.substring(0, 500)}...`
-    //             : "README not available in string format.");
-    //           console.log("...");
-    //           console.log("\nFull README available with:");
-    //           console.log(`mcp-auto-install readme ${result.serverName}`);
-    //         }
-    //       } else {
-    //         console.error(`❌ ${result.message}`);
-    //       }
-    //     } catch (error) {
-    //       console.error(`Error during auto-detection: ${(error as Error).message}`);
-    //     }
-    //     process.exit(0);
-    //   });
 
     // Add a command to save user command to config
     this.program
@@ -237,20 +210,7 @@ export class MCPCliApp {
    */
   public run() {
     // Check environment variables
-    if (!process.env.MCP_SETTINGS_PATH) {
-      console.warn('\n⚠️  Warning: MCP_SETTINGS_PATH environment variable not set');
-      console.warn(
-        'This environment variable is used to specify the path to the LLM (e.g., Claude) MCP service configuration file',
-      );
-      console.warn(
-        'To save commands to the LLM configuration file, please set this environment variable, for example:',
-      );
-      console.warn(
-        'export MCP_SETTINGS_PATH="/Users/username/Library/Application Support/Claude/claude_desktop_config.json"\n',
-      );
-    } else {
-      console.log(`📁 Using LLM config file: ${process.env.MCP_SETTINGS_PATH}`);
-    }
+    checkMCPSettings();
 
     this.program.parse(process.argv);
   }

--- a/packages/mcp-auto-install/src/index.ts
+++ b/packages/mcp-auto-install/src/index.ts
@@ -1,11 +1,26 @@
 #!/usr/bin/env node
 
 import { MCPCliApp } from './cli.js';
+import { startServer } from './server.js';
+import { checkMCPSettings } from './utils.js';
 
 /**
  * Main entry point for the MCP Auto Install application
  */
 async function main() {
+  // Check if we're in direct server mode (npx -y @mcpmarket/mcp-auto-install connect)
+  if (process.argv[2] === 'connect') {
+    try {
+      checkMCPSettings(true);
+      await startServer();
+    } catch (error) {
+      console.error('Failed to start server:', error);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Otherwise, run in CLI mode
   try {
     const cliApp = new MCPCliApp();
     cliApp.run();

--- a/packages/mcp-auto-install/src/server.ts
+++ b/packages/mcp-auto-install/src/server.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
@@ -66,7 +68,7 @@ function simpleZodToJsonSchema(schema: z.ZodType<unknown>): Record<string, unkno
 }
 
 // Set path
-const SETTINGS_PATH = path.join(homedir(), 'mcp', 'mcp_settings.json');
+const SETTINGS_PATH = path.join(homedir(), 'mcp', 'mcp-registry.json');
 
 // Server settings
 let serverSettings: { servers: MCPServerInfo[] } = { servers: [] };
@@ -384,7 +386,7 @@ async function initSettings(): Promise<void> {
       const data = await fs.readFile(SETTINGS_PATH, 'utf-8');
       serverSettings = JSON.parse(data);
     } catch (error) {
-      console.log(error);
+      console.error(error);
       // If file doesn't exist, use default settings
       serverSettings = { servers: [] };
       // Save default settings
@@ -514,7 +516,14 @@ export async function startServer(): Promise<void> {
   // Start server with standard input/output
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  console.error('MCP server started');
 }
+
+// Add direct execution support
+// startServer().catch(error => {
+//   console.error('Failed to start server:', error);
+//   process.exit(1);
+// });
 
 /**
  * Get list of registered servers

--- a/packages/mcp-auto-install/src/utils.ts
+++ b/packages/mcp-auto-install/src/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Check MCP settings environment variable
+ */
+export function checkMCPSettings(isMcp?: boolean) {
+  if (!process.env.MCP_SETTINGS_PATH) {
+    console.warn('\n⚠️  Warning: MCP_SETTINGS_PATH environment variable not set');
+    console.warn(
+      'This environment variable is used to specify the path to the LLM (e.g., Claude) MCP service configuration file',
+    );
+    console.warn(
+      'To save commands to the LLM configuration file, please set this environment variable, for example:',
+    );
+    console.warn(
+      'export MCP_SETTINGS_PATH="/Users/username/Library/Application Support/Claude/claude_desktop_config.json"\n',
+    );
+  } else {
+    console[isMcp ? 'error' : 'log'](`📁 Using LLM config file: ${process.env.MCP_SETTINGS_PATH}`);
+  }
+}

--- a/packages/mcp-auto-install/tsconfig.json
+++ b/packages/mcp-auto-install/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "preserveSymlinks": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
mcp-auto-install
  - Added MIT License file
  - Bumped version to 0.0.4 in package.json
  - Revised README for clarity and added installation instructions
  - Enhanced CLI with direct MCP connection support using npx
  - Introduced utility function to check MCP settings environment variable
  - Updated server settings path to mcp-registry.json